### PR TITLE
Docker overhaul

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+.git
+
+# copied from .gitignore
+/node_modules
+/public/hot
+/public/storage
+/storage/*.key
+/vendor
+.env
+.env.backup
+.phpunit.result.cache
+Homestead.json
+Homestead.yaml
+npm-debug.log
+yarn-error.log
+
+.vscode/
+
+_ide_helper.php
+.idea
+.config
+reports/

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,116 @@
+# Speedtest Tracker
+
+[![Docker pulls](https://img.shields.io/docker/pulls/henrywhitaker3/speedtest-tracker?style=flat-square)](https://hub.docker.com/r/henrywhitaker3/speedtest-tracker) [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/henrywhitaker3/Speedtest-Tracker/Stable?label=master&logo=github&style=flat-square)](https://github.com/henrywhitaker3/Speedtest-Tracker/actions) [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/henrywhitaker3/Speedtest-Tracker/Dev?label=dev&logo=github&style=flat-square)](https://github.com/henrywhitaker3/Speedtest-Tracker/actions) [![last_commit](https://img.shields.io/github/last-commit/henrywhitaker3/Speedtest-Tracker?style=flat-square)](https://github.com/henrywhitaker3/Speedtest-Tracker/commits) [![issues](https://img.shields.io/github/issues/henrywhitaker3/Speedtest-Tracker?style=flat-square)](https://github.com/henrywhitaker3/Speedtest-Tracker/issues) [![commit_freq](https://img.shields.io/github/commit-activity/m/henrywhitaker3/Speedtest-Tracker?style=flat-square)](https://github.com/henrywhitaker3/Speedtest-Tracker/commits) ![version](https://img.shields.io/badge/version-v1.12.0-success?style=flat-square) [![license](https://img.shields.io/github/license/henrywhitaker3/Speedtest-Tracker?style=flat-square)](https://github.com/henrywhitaker3/Speedtest-Tracker/blob/master/LICENSE)
+
+This program runs a speedtest check every hour and graphs the results. The back-end is written in [Laravel](https://laravel.com/) and the front-end uses [React](https://reactjs.org/). It uses [Ookla's Speedtest cli](https://www.speedtest.net/apps/cli) to get the data and uses [Chart.js](https://www.chartjs.org/) to plot the results.
+
+A demo site is available [here](https://speedtest.henrywhitaker.com).
+
+Disclaimer: You will need to accept Ookla's [EULA](https://www.speedtest.net/about/eula) and privacy agreements in order to use this container.
+
+![speedtest](https://user-images.githubusercontent.com/36062479/78822484-a82b8300-79ca-11ea-8525-fdeae496a0bd.gif)
+
+## Features
+
+- Automatically run a speedtest every hour
+- Graph of previous speedtests going back x days
+- Backup/restore data in JSON/CSV format
+- Slack/Discord/Telegram notifications
+- [healthchecks.io](https://healthchecks.io) integration
+- Organizr integration
+
+## Usage
+
+```bash
+docker create \
+      --name=speedtest \
+      -p 8765:80 \
+      -v /path/to/data:/config \
+      -e OOKLA_EULA_GDPR=true \
+      --restart unless-stopped \
+      henrywhitaker3/speedtest-tracker
+```
+
+### Docker compose
+
+```yml
+version: '3.3'
+services:
+    speedtest:
+        container_name: speedtest
+        image: henrywhitaker3/speedtest-tracker
+        ports:
+            - 8765:80
+        volumes:
+            - /path/to/data:/config
+        environment:
+            - TZ=
+            - PGID=
+            - PUID=
+            - OOKLA_EULA_GDPR=true
+        logging:
+            driver: "json-file"
+            options:
+                max-file: "10"
+                max-size: "200k"
+        restart: unless-stopped
+```
+
+#### Images
+
+There are 2 different docker images:
+
+| Tag | Description |
+| :----: | --- |
+| latest | This is the stable release of the app |
+| dev | This release has more features, although could have some bugs |
+
+### Parameters
+
+Container images are configured using parameters passed at runtime (such as those above). These parameters are separated by a colon and indicate `<external>:<internal>` respectively. For example, `-p 8080:80` would expose port `80` from inside the container to be accessible from the host's IP on port `8080` outside the container.
+
+|     Parameter             |   Function    |
+|     :----:                |   --- |
+|     `-p 8765:80`          |   Exposes the webserver on port 8765  |
+|     `-v /config`          |   All the config files reside here.   |
+|     `-e OOKLA_EULA_GDPR`  |   Set to 'true' to accept the Ookla [EULA](https://www.speedtest.net/about/eula) and privacy agreement. If this is not set, the container will not start   |
+|     `-e SLACK_WEBHOOK`    |   Optional. Put a slack webhook here to get slack notifications when a speedtest is run. To use discord webhooks, just append `/slack` to the end of your discord webhook URL   |
+|     `-e TELEGRAM_BOT_TOKEN`    |   Optional. Telegram bot API token.   |
+|     `-e TELEGRAM_CHAT_ID`    |   Optional. Telegram chat ID.   |
+|     `-e PUID`             |   Optional. Supply a local user ID for volume permissions   |
+|     `-e PGID`             |   Optional. Supply a local group ID for volume permissions  |
+|     `-e AUTH`             |   Optional. Set to 'true' to enable authentication for the app |
+
+### Authentication
+
+Authentication is optional. When enabled, unauthenticated users will only be able to see the graphs and tests table. To be able to queue a new speedtest, backup/restore data and update instance settings you will need to log in. To enable authentication, pass the `AUTH=true` environment variable.
+
+The default credentials are:
+
+|   Field       |   Function        |
+|   ---         |   ---             |
+|   username    |   admin@admin.com |
+|   password    |   password        |
+    
+After enabling, you should change the password through the web UI.
+
+## Getting the Image
+
+To get the base image, you have 2 options:
+
+- Use the pre-built image on dockerhub
+- Build the image yourself
+
+### Pre-built Image
+
+Run `docker pull henrywhitaker3/speedtest-tracker`
+
+<!-- ### Dockerfile
+
+Clone the required files from the github repo [here](https://github.com/henrywhitaker3/Speedtest-Tracker/tree/docker) making sure to use the `docker` branch of the repo.
+
+Build the image from the docker file by running (within the cloned git repo):
+
+```bash
+docker build . -f Dockerfile --tag=henrywhitaker3/speedtest-tracker:<tag>
+``` -->

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -105,12 +105,20 @@ To get the base image, you have 2 options:
 
 Run `docker pull henrywhitaker3/speedtest-tracker`
 
-<!-- ### Dockerfile
+### Self-built Image
 
-Clone the required files from the github repo [here](https://github.com/henrywhitaker3/Speedtest-Tracker/tree/docker) making sure to use the `docker` branch of the repo.
+Clone this repo and use docker build:
 
-Build the image from the docker file by running (within the cloned git repo):
+```
+git clone -b master --single-branch https://github.com/henrywhitaker3/Speedtest-Tracker
+cd Speedtest-Tracker
+docker build -t henrywhitaker3/speedtest-tracker:latest .
+```
+
+If you want to build for all architectures using qemu:
 
 ```bash
-docker build . -f Dockerfile --tag=henrywhitaker3/speedtest-tracker:<tag>
-``` -->
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker buildx create --use
+docker buildx build --platform linux/arm64/v8,linux/amd64 -t henrywhitaker3/speedtest-tracker:latest .
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:lts AS builder
+
+WORKDIR /build
+
+# can't cache because everything is being copied over
+# TODO: move web ui things into seperate folder
+COPY . /build
+
+RUN \
+npm ci && \
+npm run production && \
+rm -rf node_modules
+
+FROM linuxserver/nginx:latest
+LABEL maintainer=henrywhitaker3@outlook.com
+
+COPY docker/ /
+COPY --from=builder /build/ /site/
+
+EXPOSE 80 443
+
+VOLUME [ "/config" ]

--- a/app/Utils/OoklaTester.php
+++ b/app/Utils/OoklaTester.php
@@ -78,10 +78,10 @@ class OoklaTester implements SpeedtestProvider
                 return false;
             }
 
-            return shell_exec($homePrefix . $binPath . ' -f json -s ' . $server);
+            return shell_exec($homePrefix . $binPath . ' --accept-license --accept-gdpr -f json -s ' . $server);
         }
 
-        return shell_exec($homePrefix . $binPath . ' -f json');
+        return shell_exec($homePrefix . $binPath . ' --accept-license --accept-gdpr -f json');
     }
 
     /**

--- a/docker/defaults/crontab
+++ b/docker/defaults/crontab
@@ -1,0 +1,10 @@
+# do daily/weekly/monthly maintenance
+# min   hour    day     month   weekday command
+*/15    *       *       *       *       run-parts /etc/periodic/15min
+0       *       *       *       *       run-parts /etc/periodic/hourly
+0       2       *       *       *       run-parts /etc/periodic/daily
+0       3       *       *       6       run-parts /etc/periodic/weekly
+0       5       1       *       *       run-parts /etc/periodic/monthly
+# speedtest cron
+* * * * * php /config/www/artisan schedule:run >> /config/log/speedtest/cron.log
+# */5 * * * * php /config/www/artisan queue:retry all >> /config/log/speedtest.cron.log

--- a/docker/defaults/default
+++ b/docker/defaults/default
@@ -1,0 +1,8 @@
+server { listen 80 default_server; listen 443 ssl; root /config/www/public;
+index index.html index.htm index.php; server_name _; ssl_certificate
+/config/keys/cert.crt; ssl_certificate_key /config/keys/cert.key;
+client_max_body_size 0; location / { try_files $uri $uri/ /index.php?$args; }
+location ~ \.php$ { fastcgi_split_path_info ^(.+\.php)(/.+)$; # With php5-cgi
+alone: fastcgi_pass 127.0.0.1:9000; # With php5-fpm: #fastcgi_pass
+unix:/var/run/php5-fpm.sock; fastcgi_index index.php; include
+/etc/nginx/fastcgi_params; } }

--- a/docker/etc/cont-init.d/50-speedtest
+++ b/docker/etc/cont-init.d/50-speedtest
@@ -1,0 +1,139 @@
+#!/usr/bin/with-contenv bash
+
+# This script sets up the speedtest app
+
+function eulaError()
+{
+    echo "##################################################################################################################################"
+    echo "##################################################################################################################################"
+    echo "You haven't accepted the Ookla EULA. Please re-create the container with the environment variable 'OOKLA_EULA_GDPR' set to 'true'."
+    echo "##################################################################################################################################"
+    echo "##################################################################################################################################"
+    exit 1
+}
+
+# Do Ookla stuff
+if [ -z ${OOKLA_EULA_GDPR+x} ]; then
+    eulaError
+else
+    if [ $OOKLA_EULA_GDPR != "true" ]; then
+        eulaError
+    fi
+
+    if [ ! -f /config/www/app/Bin/speedtest ]; then
+        echo "Ookla GDPR and EULA accepted. Downloading Speedtest CLI."
+        cd /tmp
+
+        if [ $(uname -m) == "x86_64" ]; then
+            wget https://install.speedtest.net/app/cli/ookla-speedtest-1.0.0-x86_64-linux.tgz -O speedtest.tgz > /dev/null
+        else
+            wget https://install.speedtest.net/app/cli/ookla-speedtest-1.0.0-arm-linux.tgz -O speedtest.tgz > /dev/null
+        fi
+        
+        tar zxvf speedtest.tgz > /dev/null
+        cp speedtest /site/app/Bin/
+    fi
+fi
+
+# Copy site files to /config
+echo "Copying latest site files to config"
+cp -rfT /site/ /config/www/
+
+# Check for DB
+if [ ! -f /config/speed.db ]; then
+    echo "Database file not found! Creating empty database"
+    touch /config/speed.db
+else
+    echo "Database file exists"
+    chown abc:abc /config/speed.db
+fi
+
+# Check for .env
+if [ ! -f /config/www/.env ]; then
+    echo "Env file not found! Creating .env file"
+    cp /site/.env.example /config/www/.env
+else
+    echo "Env file exists"
+fi
+
+if [ ! -f /config/www/.composer-time ]; then
+    echo 'Removing old packages'
+    rm -rf /config/www/vendor/
+fi
+
+echo 'Updating packages'
+apk add composer
+cd /config/www && composer install && echo date > /config/www/.composer-time
+
+sed "s,DB_DATABASE=.*,DB_DATABASE=/config/speed.db," -i.bak /config/www/.env
+
+echo "Running database migrations"
+php /config/www/artisan migrate
+
+# Check app key exists
+if grep -E "APP_KEY=[0-9A-Za-z:+\/=]{1,}" /config/www/.env > /dev/null; then
+    echo "App key exists"
+else
+    echo "Generating app key"
+    php /config/www/artisan key:generate
+fi
+
+# Check JWT secret exists
+if grep -E "JWT_SECRET=[0-9A-Za-z:+\/=]{1,}" /config/www/.env > /dev/null ; then
+    echo "JWT secret exists"
+else
+    echo "Generating JWT secret"
+    php /config/www/artisan jwt:secret
+fi
+
+if [ -z ${SLACK_WEBHOOK+x} ]; then
+    echo "Slack webhook is unset"
+    sed "s,SLACK_WEBHOOK=.*,SLACK_WEBHOOK=," -i.bak /config/www/.env
+else
+    echo "Slack webhook set, updating db"
+    sed "s,SLACK_WEBHOOK=.*,SLACK_WEBHOOK=$SLACK_WEBHOOK," -i.bak /config/www/.env
+    php /config/www/artisan speedtest:slack $SLACK_WEBHOOK
+fi
+
+if [ -z ${TELEGRAM_BOT_TOKEN+x} ] && [ -z ${TELEGRAM_CHAT_ID+x} ]; then
+    echo "Telegram chat id and bot token unset"
+    sed "s,TELEGRAM_BOT_TOKEN=.*,TELEGRAM_BOT_TOKEN=," -i.bak /config/www/.env
+    sed "s,TELEGRAM_CHAT_ID=.*,TELEGRAM_CHAT_ID=," -i.bak /config/www/.env
+else
+    echo "Telegram chat id and bot token set, updating .env"
+    sed "s,TELEGRAM_BOT_TOKEN=.*,TELEGRAM_BOT_TOKEN=$TELEGRAM_BOT_TOKEN," -i.bak /config/www/.env
+    sed "s,TELEGRAM_CHAT_ID=.*,TELEGRAM_CHAT_ID=$TELEGRAM_CHAT_ID," -i.bak /config/www/.env
+    php /config/www/artisan speedtest:telegram --chat=$TELEGRAM_CHAT_ID --bot=$TELEGRAM_BOT_TOKEN
+fi
+
+if [ -z ${BASE_PATH+x} ]; then
+    echo "Base path is unset"
+    sed "s,BASE_PATH=.*,BASE_PATH=," -i.bak /config/www/.env
+else
+    echo "Base path set, updating .env"
+    sed "s,BASE_PATH=.*,BASE_PATH=$BASE_PATH," -i.bak /config/www/.env
+fi
+
+if [ -z ${AUTH+x} ]; then
+    echo "AUTH variable not set. Disabling authentication"
+    php /config/www/artisan speedtest:auth --disable
+else
+    if [ $AUTH == 'true' ]; then
+        echo "AUTH variable set. Enabling authentication"
+        php /config/www/artisan speedtest:auth --enable
+    else
+        echo "AUTH variable set, but not to 'true'. Disabling authentication"
+        php /config/www/artisan speedtest:auth --disable
+    fi
+fi
+
+echo "Clearing old jobs from queue"
+php /config/www/artisan queue:clear
+
+mkdir -p /config/log/speedtest
+
+cp /defaults/crontab /etc/crontabs/root
+
+chown -R abc:abc /config
+chmod +x /config/www/app/Bin/speedtest
+chmod -R 777 /config/www/storage/clockwork

--- a/docker/etc/php7/php-fpm.d/www.conf
+++ b/docker/etc/php7/php-fpm.d/www.conf
@@ -1,0 +1,439 @@
+; Start a new pool named 'www'.
+; the variable $pool can be used in any directive and will be replaced by the
+; pool name ('www' here)
+[www]
+
+; Per pool prefix
+; It only applies on the following directives:
+; - 'access.log'
+; - 'slowlog'
+; - 'listen' (unixsocket)
+; - 'chroot'
+; - 'chdir'
+; - 'php_values'
+; - 'php_admin_values'
+; When not set, the global prefix (or /usr) applies instead.
+; Note: This directive can also be relative to the global prefix.
+; Default Value: none
+;prefix = /path/to/pools/$pool
+
+; Unix user/group of processes
+; Note: The user is mandatory. If the group is not set, the default user's group
+;       will be used.
+user = abc
+group = abc
+
+; The address on which to accept FastCGI requests.
+; Valid syntaxes are:
+;   'ip.add.re.ss:port'    - to listen on a TCP socket to a specific IPv4 address on
+;                            a specific port;
+;   '[ip:6:addr:ess]:port' - to listen on a TCP socket to a specific IPv6 address on
+;                            a specific port;
+;   'port'                 - to listen on a TCP socket to all addresses
+;                            (IPv6 and IPv4-mapped) on a specific port;
+;   '/path/to/unix/socket' - to listen on a unix socket.
+; Note: This value is mandatory.
+listen = 127.0.0.1:9000
+
+; Set listen(2) backlog.
+; Default Value: 511 (-1 on FreeBSD and OpenBSD)
+;listen.backlog = 511
+
+; Set permissions for unix socket, if one is used. In Linux, read/write
+; permissions must be set in order to allow connections from a web server. Many
+; BSD-derived systems allow connections regardless of permissions. The owner
+; and group can be specified either by name or by their numeric IDs.
+; Default Values: user and group are set as the running user
+;                 mode is set to 0660
+;listen.owner = nobody
+;listen.group = abc
+;listen.mode = 0660
+; When POSIX Access Control Lists are supported you can set them using
+; these options, value is a comma separated list of user/group names.
+; When set, listen.owner and listen.group are ignored
+;listen.acl_users =
+;listen.acl_groups =
+
+; List of addresses (IPv4/IPv6) of FastCGI clients which are allowed to connect.
+; Equivalent to the FCGI_WEB_SERVER_ADDRS environment variable in the original
+; PHP FCGI (5.2.2+). Makes sense only with a tcp listening socket. Each address
+; must be separated by a comma. If this value is left blank, connections will be
+; accepted from any ip address.
+; Default Value: any
+;listen.allowed_clients = 127.0.0.1
+
+; Specify the nice(2) priority to apply to the pool processes (only if set)
+; The value can vary from -19 (highest priority) to 20 (lower priority)
+; Note: - It will only work if the FPM master process is launched as root
+;       - The pool processes will inherit the master process priority
+;         unless it specified otherwise
+; Default Value: no set
+; process.priority = -19
+
+; Set the process dumpable flag (PR_SET_DUMPABLE prctl) even if the process user
+; or group is differrent than the master process user. It allows to create process
+; core dump and ptrace the process for the pool user.
+; Default Value: no
+; process.dumpable = yes
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives. With this process management, there will be
+;             always at least 1 children.
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+;  ondemand - no children are created at startup. Children will be forked when
+;             new requests will connect. The following parameter are used:
+;             pm.max_children           - the maximum number of children that
+;                                         can be alive at the same time.
+;             pm.process_idle_timeout   - The number of seconds after which
+;                                         an idle process will be killed.
+; Note: This value is mandatory.
+pm = dynamic
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 5
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: (min_spare_servers + max_spare_servers) / 2
+pm.start_servers = 2
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = 1
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = 3
+
+; The number of seconds after which an idle process will be killed.
+; Note: Used only when pm is set to 'ondemand'
+; Default Value: 10s
+;pm.process_idle_timeout = 10s;
+
+; The number of requests each child process should execute before respawning.
+; This can be useful to work around memory leaks in 3rd party libraries. For
+; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
+; Default Value: 0
+;pm.max_requests = 500
+
+; The URI to view the FPM status page. If this value is not set, no URI will be
+; recognized as a status page. It shows the following informations:
+;   pool                 - the name of the pool;
+;   process manager      - static, dynamic or ondemand;
+;   start time           - the date and time FPM has started;
+;   start since          - number of seconds since FPM has started;
+;   accepted conn        - the number of request accepted by the pool;
+;   listen queue         - the number of request in the queue of pending
+;                          connections (see backlog in listen(2));
+;   max listen queue     - the maximum number of requests in the queue
+;                          of pending connections since FPM has started;
+;   listen queue len     - the size of the socket queue of pending connections;
+;   idle processes       - the number of idle processes;
+;   active processes     - the number of active processes;
+;   total processes      - the number of idle + active processes;
+;   max active processes - the maximum number of active processes since FPM
+;                          has started;
+;   max children reached - number of times, the process limit has been reached,
+;                          when pm tries to start more children (works only for
+;                          pm 'dynamic' and 'ondemand');
+; Value are updated in real time.
+; Example output:
+;   pool:                 www
+;   process manager:      static
+;   start time:           01/Jul/2011:17:53:49 +0200
+;   start since:          62636
+;   accepted conn:        190460
+;   listen queue:         0
+;   max listen queue:     1
+;   listen queue len:     42
+;   idle processes:       4
+;   active processes:     11
+;   total processes:      15
+;   max active processes: 12
+;   max children reached: 0
+;
+; By default the status page output is formatted as text/plain. Passing either
+; 'html', 'xml' or 'json' in the query string will return the corresponding
+; output syntax. Example:
+;   http://www.foo.bar/status
+;   http://www.foo.bar/status?json
+;   http://www.foo.bar/status?html
+;   http://www.foo.bar/status?xml
+;
+; By default the status page only outputs short status. Passing 'full' in the
+; query string will also return status for each pool process.
+; Example:
+;   http://www.foo.bar/status?full
+;   http://www.foo.bar/status?json&full
+;   http://www.foo.bar/status?html&full
+;   http://www.foo.bar/status?xml&full
+; The Full status returns for each process:
+;   pid                  - the PID of the process;
+;   state                - the state of the process (Idle, Running, ...);
+;   start time           - the date and time the process has started;
+;   start since          - the number of seconds since the process has started;
+;   requests             - the number of requests the process has served;
+;   request duration     - the duration in µs of the requests;
+;   request method       - the request method (GET, POST, ...);
+;   request URI          - the request URI with the query string;
+;   content length       - the content length of the request (only with POST);
+;   user                 - the user (PHP_AUTH_USER) (or '-' if not set);
+;   script               - the main script called (or '-' if not set);
+;   last request cpu     - the %cpu the last request consumed
+;                          it's always 0 if the process is not in Idle state
+;                          because CPU calculation is done when the request
+;                          processing has terminated;
+;   last request memory  - the max amount of memory the last request consumed
+;                          it's always 0 if the process is not in Idle state
+;                          because memory calculation is done when the request
+;                          processing has terminated;
+; If the process is in Idle state, then informations are related to the
+; last request the process has served. Otherwise informations are related to
+; the current request being served.
+; Example output:
+;   ************************
+;   pid:                  31330
+;   state:                Running
+;   start time:           01/Jul/2011:17:53:49 +0200
+;   start since:          63087
+;   requests:             12808
+;   request duration:     1250261
+;   request method:       GET
+;   request URI:          /test_mem.php?N=10000
+;   content length:       0
+;   user:                 -
+;   script:               /home/fat/web/docs/php/test_mem.php
+;   last request cpu:     0.00
+;   last request memory:  0
+;
+; Note: There is a real-time FPM status monitoring sample web page available
+;       It's available in: /usr/share/php7/fpm/status.html
+;
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;pm.status_path = /status
+
+; The ping URI to call the monitoring page of FPM. If this value is not set, no
+; URI will be recognized as a ping page. This could be used to test from outside
+; that FPM is alive and responding, or to
+; - create a graph of FPM availability (rrd or such);
+; - remove a server from a group if it is not responding (load balancing);
+; - trigger alerts for the operating team (24/7).
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;ping.path = /ping
+
+; This directive may be used to customize the response of a ping request. The
+; response is formatted as text/plain with a 200 response code.
+; Default Value: pong
+;ping.response = pong
+
+; The access log file
+; Default: not set
+;access.log = log/php7/$pool.access.log
+
+; The access log format.
+; The following syntax is allowed
+;  %%: the '%' character
+;  %C: %CPU used by the request
+;      it can accept the following format:
+;      - %{user}C for user CPU only
+;      - %{system}C for system CPU only
+;      - %{total}C  for user + system CPU (default)
+;  %d: time taken to serve the request
+;      it can accept the following format:
+;      - %{seconds}d (default)
+;      - %{miliseconds}d
+;      - %{mili}d
+;      - %{microseconds}d
+;      - %{micro}d
+;  %e: an environment variable (same as $_ENV or $_SERVER)
+;      it must be associated with embraces to specify the name of the env
+;      variable. Some exemples:
+;      - server specifics like: %{REQUEST_METHOD}e or %{SERVER_PROTOCOL}e
+;      - HTTP headers like: %{HTTP_HOST}e or %{HTTP_USER_AGENT}e
+;  %f: script filename
+;  %l: content-length of the request (for POST request only)
+;  %m: request method
+;  %M: peak of memory allocated by PHP
+;      it can accept the following format:
+;      - %{bytes}M (default)
+;      - %{kilobytes}M
+;      - %{kilo}M
+;      - %{megabytes}M
+;      - %{mega}M
+;  %n: pool name
+;  %o: output header
+;      it must be associated with embraces to specify the name of the header:
+;      - %{Content-Type}o
+;      - %{X-Powered-By}o
+;      - %{Transfert-Encoding}o
+;      - ....
+;  %p: PID of the child that serviced the request
+;  %P: PID of the parent of the child that serviced the request
+;  %q: the query string
+;  %Q: the '?' character if query string exists
+;  %r: the request URI (without the query string, see %q and %Q)
+;  %R: remote IP address
+;  %s: status (response code)
+;  %t: server time the request was received
+;      it can accept a strftime(3) format:
+;      %d/%b/%Y:%H:%M:%S %z (default)
+;      The strftime(3) format must be encapsuled in a %{<strftime_format>}t tag
+;      e.g. for a ISO8601 formatted timestring, use: %{%Y-%m-%dT%H:%M:%S%z}t
+;  %T: time the log has been written (the request has finished)
+;      it can accept a strftime(3) format:
+;      %d/%b/%Y:%H:%M:%S %z (default)
+;      The strftime(3) format must be encapsuled in a %{<strftime_format>}t tag
+;      e.g. for a ISO8601 formatted timestring, use: %{%Y-%m-%dT%H:%M:%S%z}t
+;  %u: remote user
+;
+; Default: "%R - %u %t \"%m %r\" %s"
+;access.format = "%R - %u %t \"%m %r%Q%q\" %s %f %{mili}d %{kilo}M %C%%"
+
+; The log file for slow requests
+; Default Value: not set
+; Note: slowlog is mandatory if request_slowlog_timeout is set
+;slowlog = log/php7/$pool.slow.log
+
+; The timeout for serving a single request after which a PHP backtrace will be
+; dumped to the 'slowlog' file. A value of '0s' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_slowlog_timeout = 0
+
+; Depth of slow log stack trace.
+; Default Value: 20
+;request_slowlog_trace_depth = 20
+
+; The timeout for serving a single request after which the worker process will
+; be killed. This option should be used when the 'max_execution_time' ini option
+; does not stop script execution for some reason. A value of '0' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_terminate_timeout = 0
+
+; The timeout set by 'request_terminate_timeout' ini option is not engaged after
+; application calls 'fastcgi_finish_request' or when application has finished and
+; shutdown functions are being called (registered via register_shutdown_function).
+; This option will enable timeout limit to be applied unconditionally
+; even in such cases.
+; Default Value: no
+;request_terminate_timeout_track_finished = no
+
+; Set open file descriptor rlimit.
+; Default Value: system defined value
+;rlimit_files = 1024
+
+; Set max core size rlimit.
+; Possible Values: 'unlimited' or an integer greater or equal to 0
+; Default Value: system defined value
+;rlimit_core = 0
+
+; Chroot to this directory at the start. This value must be defined as an
+; absolute path. When this value is not set, chroot is not used.
+; Note: you can prefix with '$prefix' to chroot to the pool prefix or one
+; of its subdirectories. If the pool prefix is not set, the global prefix
+; will be used instead.
+; Note: chrooting is a great security feature and should be used whenever
+;       possible. However, all PHP paths will be relative to the chroot
+;       (error_log, sessions.save_path, ...).
+; Default Value: not set
+;chroot =
+
+; Chdir to this directory at the start.
+; Note: relative path can be used.
+; Default Value: current directory or / when chroot
+;chdir = /var/www
+
+; Redirect worker stdout and stderr into main error log. If not set, stdout and
+; stderr will be redirected to /dev/null according to FastCGI specs.
+; Note: on highloaded environement, this can cause some delay in the page
+; process time (several ms).
+; Default Value: no
+;catch_workers_output = yes
+
+; Decorate worker output with prefix and suffix containing information about
+; the child that writes to the log and if stdout or stderr is used as well as
+; log level and time. This options is used only if catch_workers_output is yes.
+; Settings to "no" will output data as written to the stdout or stderr.
+; Default value: yes
+;decorate_workers_output = no
+
+; Clear environment in FPM workers
+; Prevents arbitrary environment variables from reaching FPM worker processes
+; by clearing the environment in workers before env vars specified in this
+; pool configuration are added.
+; Setting to "no" will make all environment variables available to PHP code
+; via getenv(), $_ENV and $_SERVER.
+; Default Value: yes
+clear_env = no
+
+; Limits the extensions of the main script FPM will allow to parse. This can
+; prevent configuration mistakes on the web server side. You should only limit
+; FPM to .php extensions to prevent malicious users to use other extensions to
+; execute php code.
+; Note: set an empty value to allow all extensions.
+; Default Value: .php
+;security.limit_extensions = .php .php3 .php4 .php5 .php7
+
+; Pass environment variables like LD_LIBRARY_PATH. All $VARIABLEs are taken from
+; the current environment.
+; Default Value: clean env
+;env[HOSTNAME] = $HOSTNAME
+;env[PATH] = /usr/local/bin:/usr/bin:/bin
+;env[TMP] = /tmp
+;env[TMPDIR] = /tmp
+;env[TEMP] = /tmp
+
+; Additional php.ini defines, specific to this pool of workers. These settings
+; overwrite the values previously defined in the php.ini. The directives are the
+; same as the PHP SAPI:
+;   php_value/php_flag             - you can set classic ini defines which can
+;                                    be overwritten from PHP call 'ini_set'.
+;   php_admin_value/php_admin_flag - these directives won't be overwritten by
+;                                     PHP call 'ini_set'
+; For php_*flag, valid values are on, off, 1, 0, true, false, yes or no.
+
+; Defining 'extension' will load the corresponding shared extension from
+; extension_dir. Defining 'disable_functions' or 'disable_classes' will not
+; overwrite previously defined php.ini values, but will append the new value
+; instead.
+
+; Note: path INI options can be relative and will be expanded with the prefix
+; (pool, global or /usr)
+
+; Default Value: nothing is defined by default except the values in php.ini and
+;                specified at startup with the -d argument
+;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
+;php_flag[display_errors] = off
+;php_admin_value[error_log] = /var/log/php7/$pool.error.log
+;php_admin_flag[log_errors] = on
+;php_admin_value[memory_limit] = 32M

--- a/docker/etc/services.d/speedtest/run
+++ b/docker/etc/services.d/speedtest/run
@@ -1,0 +1,3 @@
+#!/usr/bin/with-contenv bash
+
+exec s6-setuidgid abc php /config/www/artisan queue:work --timeout=120 >> /config/log/speedtest/queue.log


### PR DESCRIPTION
I moved Docker things over into the master branch. This is the normal way to do it. Now anyone can jump to any commit and just build the Docker file without understanding npm, php and the Docker config files.

I also moved `--accept-license --accept-gdpr` out of `50-speedtest` and into `OoklaTester.php` because it didn't persist well for me.

And I removed the `ARCH` environment variable used by `50-speedtest` and instead used `uname -m` to determine the architecture.

There are still some issues with the Docker setup such as php dependencies being installed at runtime, and the web ui should be in a seperate folder (check the Dockerfile). But this is a good start to making it super easy for anyone to self-compile speedtest tracker!

As a side note... when pushing, please please please build with two tags. Version tag and then latest tag. This was an issue here: https://github.com/henrywhitaker3/Speedtest-Tracker/issues/680#issuecomment-913076930 and I had to provide a tar.gz to help them out.

I moved the `README.md` from the old docker branch into master as `DOCKER.md` and updated it with new build instructions. Here's an example of how you'd normally build multi-arch images with a version tag:

```bash
# initialize qemu and buildx
docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
docker buildx create --use

# build for arm64/v8 and amd64
cd into/git/repo
docker buildx build --platform linux/arm64/v8,linux/amd64 -t henrywhitaker3/speedtest-tracker:VERSIONHERE -t henrywhitaker3/speedtest-tracker:latest .

# push the image as two tags! the second push will be fast because it's identical to the first
docker push -t henrywhitaker3/speedtest-tracker:VERSIONHERE
docker push -t henrywhitaker3/speedtest-tracker:latest
```
