### PR TITLE
Push speedtest cli to new version

### DIFF
--- a/conf/etc/cont-init.d/50-speedtest
+++ b/conf/etc/cont-init.d/50-speedtest
@@ -22,7 +22,7 @@ else
     if [ ! -f /config/www/app/Bin/speedtest ]; then
         echo "Ookla GDPR and EULA accepted. Downloading Speedtest CLI."
         cd /tmp
-        wget https://install.speedtest.net/app/cli/ookla-speedtest-1.0.0-$arch-linux.tgz -O speedtest.tgz > /dev/null
+        wget https://install.speedtest.net/app/cli/ookla-speedtest-1.1.1-linux-$arch.tgz -O speedtest.tgz > /dev/null
         tar zxvf speedtest.tgz > /dev/null
         cp speedtest /site/app/Bin/
 


### PR DESCRIPTION
The link to the old CLI was not working anymore, so I added the new version. Does work on my docker fine, so I assume no changes to the CLI have been made, which can break the system here.